### PR TITLE
Feature/basic instructions

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,190 @@
+/// Utility function that allows us to quickly just grab the specified bits
+fn from_bits(value: u16, size: u16, offset: u16) -> u16 {
+    (value >> offset) & ((1 << size) - 1)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum OperationCode {
+    Branch,
+    Add,
+    Load,
+    Store,
+    JumpRegister,
+    And,
+    LoadRegister,
+    StoreRegister,
+    /// Unused
+    Rti,
+    Not,
+    LoadIndirect,
+    StoreIndirect,
+    Jump,
+    /// Unused
+    Reserved,
+    LoadEffectiveAddress,
+    ExecuteTrap,
+}
+
+impl OperationCode {
+    fn from_u16(value: u16) -> Self {
+        match value {
+            0 => Self::Branch,
+            1 => Self::Add,
+            2 => Self::Load,
+            3 => Self::Store,
+            4 => Self::JumpRegister,
+            5 => Self::And,
+            6 => Self::LoadRegister,
+            7 => Self::StoreRegister,
+            8 => Self::Rti,
+            9 => Self::Not,
+            10 => Self::LoadIndirect,
+            11 => Self::StoreIndirect,
+            12 => Self::Jump,
+            14 => Self::LoadEffectiveAddress,
+            15 => Self::ExecuteTrap,
+            _ => Self::Reserved, // We create noops for any other operation code
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ConditionFlag {
+    Positive = 1 << 0,
+    Zero = 1 << 1,
+    Negative = 1 << 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Register {
+    R0,
+    R1,
+    R2,
+    R3,
+    R4,
+    R5,
+    R6,
+    R7,
+    PC, /* program counter */
+    Cond,
+}
+/// Number of available registers
+pub const REGISTER_COUNTER: usize = 10;
+
+impl Register {
+    fn from_u16(value: u16) -> Self {
+        match value {
+            0 => Self::R0,
+            1 => Self::R1,
+            2 => Self::R2,
+            3 => Self::R3,
+            4 => Self::R4,
+            5 => Self::R5,
+            6 => Self::R6,
+            7 => Self::R7,
+            8 => Self::PC,
+            _ => Self::Cond,
+        }
+    }
+
+    fn from_bits(value: u16, offset: u16) -> Self {
+        Self::from_u16(from_bits(value, 3, offset))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Instruction {
+    Add {
+        destination: Register,
+        source_1: Register,
+        source_2: Register,
+    },
+    AddImmediate {
+        destination: Register,
+        source: Register,
+        value: u16, // The value is actually limited to 5 bits
+    },
+    Noop,
+}
+
+impl Instruction {
+    fn encode(&self) -> u16 {
+        match *self {
+            Instruction::Add {
+                destination,
+                source_1,
+                source_2,
+            } => {
+                ((OperationCode::Add as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + ((source_1 as u16) << 6)
+                    + (source_2 as u16)
+            }
+            Instruction::AddImmediate {
+                destination,
+                source,
+                value,
+            } => {
+                ((OperationCode::Add as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + ((source as u16) << 6)
+                    + (1 << 5)
+                    + value
+            }
+            Instruction::Noop => 0,
+        }
+    }
+
+    fn decode(repr: u16) -> Self {
+        let code = OperationCode::from_u16(repr >> 12);
+        match code {
+            OperationCode::Branch => todo!(),
+            OperationCode::Add => Instruction::Add {
+                destination: Register::from_bits(repr, 9),
+                source_1: Register::from_bits(repr, 6),
+                source_2: Register::from_bits(repr, 0),
+            },
+            OperationCode::Load => todo!(),
+            OperationCode::Store => todo!(),
+            OperationCode::JumpRegister => todo!(),
+            OperationCode::And => todo!(),
+            OperationCode::LoadRegister => todo!(),
+            OperationCode::StoreRegister => todo!(),
+            OperationCode::Rti => todo!(),
+            OperationCode::Not => todo!(),
+            OperationCode::LoadIndirect => todo!(),
+            OperationCode::StoreIndirect => todo!(),
+            OperationCode::Jump => todo!(),
+            OperationCode::Reserved => todo!(),
+            OperationCode::LoadEffectiveAddress => todo!(),
+            OperationCode::ExecuteTrap => todo!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_add() {
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+        };
+        let encoded = instruction.encode();
+        assert_eq!(0x1001, encoded);
+    }
+
+    #[test]
+    fn decode_add() {
+        let decoded = Instruction::decode(0x1001);
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+        };
+        assert_eq!(instruction, decoded);
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -98,11 +98,8 @@ pub enum Instruction {
         destination: Register,
         source_1: Register,
         source_2: Register,
-    },
-    AddImmediate {
-        destination: Register,
-        source: Register,
-        value: u16, // The value is actually limited to 5 bits
+        mode: u16,
+        value: u16,
     },
     Noop,
 }
@@ -113,23 +110,15 @@ impl Instruction {
             Instruction::Add {
                 destination,
                 source_1,
-                source_2,
-            } => {
-                ((OperationCode::Add as u16) << 12)
-                    + ((destination as u16) << 9)
-                    + ((source_1 as u16) << 6)
-                    + (source_2 as u16)
-            }
-            Instruction::AddImmediate {
-                destination,
-                source,
+                source_2: _,
+                mode,
                 value,
             } => {
                 ((OperationCode::Add as u16) << 12)
                     + ((destination as u16) << 9)
-                    + ((source as u16) << 6)
-                    + (1 << 5)
-                    + value
+                    + ((source_1 as u16) << 6)
+                    + (mode << 5)
+                    + (value) // Kinda hack because value contains all of the bits of source_2
             }
             Instruction::Noop => 0,
         }
@@ -143,6 +132,8 @@ impl Instruction {
                 destination: Register::from_bits(repr, 9),
                 source_1: Register::from_bits(repr, 6),
                 source_2: Register::from_bits(repr, 0),
+                mode: from_bits(repr, 1, 5),
+                value: from_bits(repr, 5, 0),
             },
             OperationCode::Load => todo!(),
             OperationCode::Store => todo!(),
@@ -172,6 +163,8 @@ mod tests {
             destination: Register::R0,
             source_1: Register::R0,
             source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16
         };
         let encoded = instruction.encode();
         assert_eq!(0x1001, encoded);
@@ -184,6 +177,8 @@ mod tests {
             destination: Register::R0,
             source_1: Register::R0,
             source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16
         };
         assert_eq!(instruction, decoded);
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -164,7 +164,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 0,
-            value: Register::R1 as u16
+            value: Register::R1 as u16,
         };
         let encoded = instruction.encode();
         assert_eq!(0x1001, encoded);
@@ -178,7 +178,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 0,
-            value: Register::R1 as u16
+            value: Register::R1 as u16,
         };
         assert_eq!(instruction, decoded);
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -3,6 +3,18 @@ fn from_bits(value: u16, size: u16, offset: u16) -> u16 {
     (value >> offset) & ((1 << size) - 1)
 }
 
+/// Utility function that grabs the results of from_bits and extends
+/// the sign by adding 1s to the missing bits. This conforms to the two's
+/// compliment signed number scheme
+pub fn from_bits_signed(value: u16, size: u16) -> u16 {
+    if ((value >> (size - 1)) & 1) == 1 {
+        let mask = 0xFFFF << (size - 1);
+        from_bits(value, size - 1, 0) | mask
+    } else {
+        from_bits(value, size - 1, 0)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum OperationCode {
     Branch,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -3,15 +3,15 @@ fn from_bits(value: u16, size: u16, offset: u16) -> u16 {
     (value >> offset) & ((1 << size) - 1)
 }
 
-/// Utility function that grabs the results of from_bits and extends
+/// Utility function that grabs the u16 and extends
 /// the sign by adding 1s to the missing bits. This conforms to the two's
 /// compliment signed number scheme
-pub fn from_bits_signed(value: u16, size: u16) -> u16 {
+fn from_bits_signed(value: u16, size: u16, offset: u16) -> u16 {
     if ((value >> (size - 1)) & 1) == 1 {
         let mask = 0xFFFF << (size - 1);
-        from_bits(value, size - 1, 0) | mask
+        from_bits(value, size - 1, offset) | mask
     } else {
-        from_bits(value, size - 1, 0)
+        from_bits(value, size - 1, offset)
     }
 }
 
@@ -130,7 +130,7 @@ impl Instruction {
                     + ((destination as u16) << 9)
                     + ((source_1 as u16) << 6)
                     + (mode << 5)
-                    + (value) // Kinda hack because value contains all of the bits of source_2
+                    + (value & 0x1F) // Kinda hack because value contains all of the bits of source_2
             }
             Instruction::Noop => 0,
         }
@@ -145,7 +145,7 @@ impl Instruction {
                 source_1: Register::from_bits(repr, 6),
                 source_2: Register::from_bits(repr, 0),
                 mode: from_bits(repr, 1, 5),
-                value: from_bits(repr, 5, 0),
+                value: from_bits_signed(repr, 5, 0),
             },
             OperationCode::Load => todo!(),
             OperationCode::Store => todo!(),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -95,7 +95,11 @@ impl Register {
             6 => Self::R6,
             7 => Self::R7,
             8 => Self::PC,
-            _ => Self::Cond,
+            9 => Self::Cond,
+            _ => {
+                /* consider blowing up */
+                todo!()
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use vm::VirtualMachine;
 
-mod constants;
+mod instructions;
 mod vm;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+use vm::VirtualMachine;
+
+mod constants;
+mod vm;
+
 fn main() {
+    let main_vm = VirtualMachine::new();
     println!("Hello, world!");
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,55 @@
+use crate::constants::{Instruction, REGISTER_COUNTER, Register};
+
+#[derive(Debug, Clone, Copy)]
+pub struct VirtualMachine {
+    memory: [u16; u16::MAX as usize],
+    registers: [u16; REGISTER_COUNTER],
+}
+
+impl VirtualMachine {
+    pub fn new() -> Self {
+        VirtualMachine {
+            memory: [0; u16::MAX as usize],
+            registers: [0; REGISTER_COUNTER],
+        }
+    }
+
+    fn execute_instruction(&mut self, instruction: Instruction) {
+        match instruction {
+            Instruction::Add {
+                destination,
+                source_1,
+                source_2,
+            } => self.add(destination, source_1, source_2),
+            Instruction::AddImmediate {
+                destination,
+                source,
+                value,
+            } => (),
+            _ => (),
+        }
+    }
+
+    fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
+        let value = self.registers[source_1 as usize] + self.registers[sorce_2 as usize];
+        self.registers[destination as usize] = value;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vm_add() {
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 2;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 2);
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-use crate::instructions::{Instruction, REGISTER_COUNTER, Register};
+use crate::instructions::{Instruction, REGISTER_COUNTER, Register, from_bits_signed};
 
 #[derive(Debug, Clone, Copy)]
 pub struct VirtualMachine {
@@ -39,6 +39,9 @@ impl VirtualMachine {
     }
 
     fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
+        // It's not great that the logic for signing is here
+        // but it simplifies our encoding decoding process
+        value = from_bits_signed(value, 5);
         value += self.registers[source_1 as usize];
         self.registers[destination as usize] = value;
     }
@@ -76,5 +79,35 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 5);
+    }
+
+    #[test]
+    fn vm_add_immediate_negative() {
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 0x1F, // -1
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 2;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0xFFFF);
+    }
+
+    #[test]
+    fn vm_add_immediate_negative_2() {
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 0x10, // -16
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 2;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize].wrapping_add(16), 0);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-use crate::constants::{Instruction, REGISTER_COUNTER, Register};
+use crate::instructions::{Instruction, REGISTER_COUNTER, Register};
 
 #[derive(Debug, Clone, Copy)]
 pub struct VirtualMachine {
@@ -55,7 +55,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 0,
-            value: Register::R1 as u16
+            value: Register::R1 as u16,
         };
         let mut vm = VirtualMachine::new();
         vm.registers[Register::R1 as usize] = 2;
@@ -70,7 +70,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 1,
-            value: 5
+            value: 5,
         };
         let mut vm = VirtualMachine::new();
         vm.registers[Register::R1 as usize] = 2;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -34,12 +34,12 @@ impl VirtualMachine {
     }
 
     fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
-        let value = self.registers[source_1 as usize] + self.registers[sorce_2 as usize];
+        let value = self.registers[source_1 as usize].wrapping_add(self.registers[sorce_2 as usize]);
         self.registers[destination as usize] = value;
     }
 
     fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
-        value += self.registers[source_1 as usize];
+        value = value.wrapping_add(self.registers[source_1 as usize]);
         self.registers[destination as usize] = value;
     }
 }
@@ -106,5 +106,36 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize].wrapping_add(16), 0);
+    }
+
+    #[test]
+    fn vm_add_shouldnt_panic_overflow(){
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16, // 15
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = u16::MAX;
+        vm.registers[Register::R1 as usize] = 2;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 1);
+    }
+
+    #[test]
+    fn vm_add_immediate_shouldnt_panic_overflow(){
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 0x000F, // 15
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = u16::MAX - 14;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -34,7 +34,8 @@ impl VirtualMachine {
     }
 
     fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
-        let value = self.registers[source_1 as usize].wrapping_add(self.registers[sorce_2 as usize]);
+        let value =
+            self.registers[source_1 as usize].wrapping_add(self.registers[sorce_2 as usize]);
         self.registers[destination as usize] = value;
     }
 
@@ -109,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn vm_add_shouldnt_panic_overflow(){
+    fn vm_add_shouldnt_panic_overflow() {
         let instruction = Instruction::Add {
             destination: Register::R0,
             source_1: Register::R0,
@@ -125,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn vm_add_immediate_shouldnt_panic_overflow(){
+    fn vm_add_immediate_shouldnt_panic_overflow() {
         let instruction = Instruction::Add {
             destination: Register::R0,
             source_1: Register::R0,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -20,18 +20,26 @@ impl VirtualMachine {
                 destination,
                 source_1,
                 source_2,
-            } => self.add(destination, source_1, source_2),
-            Instruction::AddImmediate {
-                destination,
-                source,
+                mode,
                 value,
-            } => (),
+            } => {
+                if mode == 0 {
+                    self.add(destination, source_1, source_2)
+                } else {
+                    self.add_immediate(destination, source_1, value);
+                }
+            }
             _ => (),
         }
     }
 
     fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
         let value = self.registers[source_1 as usize] + self.registers[sorce_2 as usize];
+        self.registers[destination as usize] = value;
+    }
+
+    fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
+        value += self.registers[source_1 as usize];
         self.registers[destination as usize] = value;
     }
 }
@@ -46,10 +54,27 @@ mod tests {
             destination: Register::R0,
             source_1: Register::R0,
             source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16
         };
         let mut vm = VirtualMachine::new();
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 2);
+    }
+
+    #[test]
+    fn vm_add_immediate() {
+        let instruction = Instruction::Add {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 5
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 2;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 5);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-use crate::instructions::{Instruction, REGISTER_COUNTER, Register, from_bits_signed};
+use crate::instructions::{Instruction, REGISTER_COUNTER, Register};
 
 #[derive(Debug, Clone, Copy)]
 pub struct VirtualMachine {
@@ -39,9 +39,6 @@ impl VirtualMachine {
     }
 
     fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
-        // It's not great that the logic for signing is here
-        // but it simplifies our encoding decoding process
-        value = from_bits_signed(value, 5);
         value += self.registers[source_1 as usize];
         self.registers[destination as usize] = value;
     }
@@ -88,7 +85,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 1,
-            value: 0x1F, // -1
+            value: 0xFFFF, // -1
         };
         let mut vm = VirtualMachine::new();
         vm.registers[Register::R1 as usize] = 2;
@@ -103,7 +100,7 @@ mod tests {
             source_1: Register::R0,
             source_2: Register::R1,
             mode: 1,
-            value: 0x10, // -16
+            value: 0xFFF0, // -16
         };
         let mut vm = VirtualMachine::new();
         vm.registers[Register::R1 as usize] = 2;


### PR DESCRIPTION
Added basic structure for the vm
The vm is composed of a simple array of registers and memory that contains all of it's working information.

For instructions, I have created variants that allow to encapsulate properly the parameters of each instruction to make it simple. This logic of decoding is encapsulated in the instructions.rs file.