### PR TITLE
Adding all instructions of the LC3 architecture (exulding trap)

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -66,6 +66,23 @@ pub enum ConditionFlag {
     Zero = 1 << 1,
     Negative = 1 << 2,
 }
+impl ConditionFlag {
+    fn from_u16(value: u16) -> Self {
+        match value {
+            1 => Self::Positive,
+            2 => Self::Zero,
+            4 => Self::Negative,
+            _ => {
+                /* consider blowing up */
+                todo!()
+            }
+        }
+    }
+
+    fn from_bits(value: u16, offset: u16) -> Self {
+        Self::from_u16(from_bits(value, 3, offset))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Register {
@@ -145,6 +162,10 @@ pub enum Instruction {
         destination: Register,
         offset: u16,
     },
+    Branch {
+        flag: ConditionFlag,
+        offset: u16,
+    },
     Noop,
 }
 
@@ -198,7 +219,7 @@ impl Instruction {
                 source,
                 offset,
             } => {
-                ((OperationCode::Load as u16) << 12)
+                ((OperationCode::LoadRegister as u16) << 12)
                     + ((destination as u16) << 9)
                     + ((source as u16) << 6)
                     + (offset & 0x3F)
@@ -219,6 +240,9 @@ impl Instruction {
                     + ((destination as u16) << 9)
                     + (offset & 0x1FF)
             }
+            Instruction::Branch { flag, offset } => {
+                ((OperationCode::Branch as u16) << 12) + ((flag as u16) << 9) + (offset & 0x1FF)
+            }
             Instruction::Noop => 0,
         }
     }
@@ -226,7 +250,10 @@ impl Instruction {
     fn decode(repr: u16) -> Self {
         let code = OperationCode::from_u16(repr >> 12);
         match code {
-            OperationCode::Branch => todo!(),
+            OperationCode::Branch => Instruction::Branch {
+                flag: ConditionFlag::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::Add => Instruction::Add {
                 destination: Register::from_bits(repr, 9),
                 source_1: Register::from_bits(repr, 6),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -117,6 +117,10 @@ pub enum Instruction {
         mode: u16,
         value: u16,
     },
+    Load {
+        destination: Register,
+        offset: u16,
+    },
     LoadIndirect {
         destination: Register,
         offset: u16,
@@ -139,6 +143,14 @@ impl Instruction {
                     + ((source_1 as u16) << 6)
                     + (mode << 5)
                     + (value & 0x1F) // Kinda hack because value contains all of the bits of source_2
+            }
+            Instruction::Load {
+                destination,
+                offset,
+            } => {
+                ((OperationCode::Load as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + (offset & 0x1FF)
             }
             Instruction::LoadIndirect {
                 destination,
@@ -163,7 +175,10 @@ impl Instruction {
                 mode: from_bits(repr, 1, 5),
                 value: from_bits_signed(repr, 5, 0),
             },
-            OperationCode::Load => todo!(),
+            OperationCode::Load => Instruction::Load {
+                destination: Register::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::Store => todo!(),
             OperationCode::JumpRegister => todo!(),
             OperationCode::And => todo!(),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -144,7 +144,9 @@ impl Instruction {
                 destination,
                 offset,
             } => {
-                ((OperationCode::LoadIndirect as u16) << 12) + ((destination as u16) << 9) + (offset & 0x1FF)
+                ((OperationCode::LoadIndirect as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + (offset & 0x1FF)
             }
             Instruction::Noop => 0,
         }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -117,6 +117,13 @@ pub enum Instruction {
         mode: u16,
         value: u16,
     },
+    And {
+        destination: Register,
+        source_1: Register,
+        source_2: Register,
+        mode: u16,
+        value: u16,
+    },
     Load {
         destination: Register,
         offset: u16,
@@ -148,6 +155,19 @@ impl Instruction {
                 value,
             } => {
                 ((OperationCode::Add as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + ((source_1 as u16) << 6)
+                    + (mode << 5)
+                    + (value & 0x1F) // Kinda hack because value contains all of the bits of source_2
+            }
+            Instruction::And {
+                destination,
+                source_1,
+                source_2,
+                mode,
+                value,
+            } => {
+                ((OperationCode::And as u16) << 12)
                     + ((destination as u16) << 9)
                     + ((source_1 as u16) << 6)
                     + (mode << 5)
@@ -208,7 +228,13 @@ impl Instruction {
             },
             OperationCode::Store => todo!(),
             OperationCode::JumpRegister => todo!(),
-            OperationCode::And => todo!(),
+            OperationCode::And => Instruction::And {
+                destination: Register::from_bits(repr, 9),
+                source_1: Register::from_bits(repr, 6),
+                source_2: Register::from_bits(repr, 0),
+                mode: from_bits(repr, 1, 5),
+                value: from_bits_signed(repr, 5, 0),
+            },
             OperationCode::LoadRegister => Instruction::LoadRegister {
                 destination: Register::from_bits(repr, 9),
                 source: Register::from_bits(repr, 6),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -61,7 +61,7 @@ impl OperationCode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum ConditionFlag {
+pub enum ConditionFlag {
     Positive = 1 << 0,
     Zero = 1 << 1,
     Negative = 1 << 2,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -166,6 +166,14 @@ pub enum Instruction {
         flag: ConditionFlag,
         offset: u16,
     },
+    Jump {
+        source: Register,
+    },
+    JumpRegister {
+        source: Register,
+        mode: u16,
+        offset: u16,
+    },
     Noop,
 }
 
@@ -243,6 +251,14 @@ impl Instruction {
             Instruction::Branch { flag, offset } => {
                 ((OperationCode::Branch as u16) << 12) + ((flag as u16) << 9) + (offset & 0x1FF)
             }
+            Instruction::Jump { source } => {
+                ((OperationCode::Jump as u16) << 12) + ((source as u16) << 6)
+            }
+            Instruction::JumpRegister {
+                source,
+                mode,
+                offset,
+            } => ((OperationCode::Jump as u16) << 12) + (mode << 11) + (offset & 0x7FF),
             Instruction::Noop => 0,
         }
     }
@@ -266,7 +282,11 @@ impl Instruction {
                 offset: from_bits_signed(repr, 9, 0),
             },
             OperationCode::Store => todo!(),
-            OperationCode::JumpRegister => todo!(),
+            OperationCode::JumpRegister => Instruction::JumpRegister {
+                source: Register::from_bits(repr, 6),
+                mode: from_bits(repr, 1, 11),
+                offset: from_bits_signed(repr, 11, 0),
+            },
             OperationCode::And => Instruction::And {
                 destination: Register::from_bits(repr, 9),
                 source_1: Register::from_bits(repr, 6),
@@ -290,7 +310,9 @@ impl Instruction {
                 offset: from_bits_signed(repr, 9, 0),
             },
             OperationCode::StoreIndirect => todo!(),
-            OperationCode::Jump => todo!(),
+            OperationCode::Jump => Instruction::Jump {
+                source: Register::from_bits(repr, 6),
+            },
             OperationCode::Reserved => todo!(),
             OperationCode::LoadEffectiveAddress => Instruction::LoadEffectiveAddress {
                 destination: Register::from_bits(repr, 9),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -174,6 +174,20 @@ pub enum Instruction {
         mode: u16,
         offset: u16,
     },
+    Store {
+        source: Register,
+        offset: u16,
+    },
+    StoreIndirect {
+        source: Register,
+        offset: u16,
+    },
+    StoreRegister {
+        // TODO: consider changing to a more descriptive name
+        source_1: Register,
+        source_2: Register,
+        offset: u16,
+    },
     Noop,
 }
 
@@ -259,6 +273,24 @@ impl Instruction {
                 mode,
                 offset,
             } => ((OperationCode::Jump as u16) << 12) + (mode << 11) + (offset & 0x7FF),
+            Instruction::Store { source, offset } => {
+                ((OperationCode::Store as u16) << 12) + ((source as u16) << 9) + (offset & 0x1FF)
+            }
+            Instruction::StoreIndirect { source, offset } => {
+                ((OperationCode::StoreIndirect as u16) << 12)
+                    + ((source as u16) << 9)
+                    + (offset & 0x1FF)
+            }
+            Instruction::StoreRegister {
+                source_1,
+                source_2,
+                offset,
+            } => {
+                ((OperationCode::StoreRegister as u16) << 12)
+                    + ((source_1 as u16) << 9)
+                    + ((source_2 as u16) << 6)
+                    + (offset & 0x3F)
+            }
             Instruction::Noop => 0,
         }
     }
@@ -281,7 +313,10 @@ impl Instruction {
                 destination: Register::from_bits(repr, 9),
                 offset: from_bits_signed(repr, 9, 0),
             },
-            OperationCode::Store => todo!(),
+            OperationCode::Store => Instruction::Store {
+                source: Register::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::JumpRegister => Instruction::JumpRegister {
                 source: Register::from_bits(repr, 6),
                 mode: from_bits(repr, 1, 11),
@@ -299,7 +334,11 @@ impl Instruction {
                 source: Register::from_bits(repr, 6),
                 offset: from_bits_signed(repr, 6, 0),
             },
-            OperationCode::StoreRegister => todo!(),
+            OperationCode::StoreRegister => Instruction::StoreRegister {
+                source_1: Register::from_bits(repr, 9),
+                source_2: Register::from_bits(repr, 6),
+                offset: from_bits_signed(repr, 6, 0),
+            },
             OperationCode::Rti => todo!(),
             OperationCode::Not => Instruction::Not {
                 destination: Register::from_bits(repr, 9),
@@ -309,7 +348,10 @@ impl Instruction {
                 destination: Register::from_bits(repr, 9),
                 offset: from_bits_signed(repr, 9, 0),
             },
-            OperationCode::StoreIndirect => todo!(),
+            OperationCode::StoreIndirect => Instruction::StoreIndirect {
+                source: Register::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::Jump => Instruction::Jump {
                 source: Register::from_bits(repr, 6),
             },

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -121,7 +121,16 @@ pub enum Instruction {
         destination: Register,
         offset: u16,
     },
+    LoadRegister {
+        destination: Register,
+        source: Register,
+        offset: u16,
+    },
     LoadIndirect {
+        destination: Register,
+        offset: u16,
+    },
+    LoadEffectiveAddress {
         destination: Register,
         offset: u16,
     },
@@ -152,11 +161,29 @@ impl Instruction {
                     + ((destination as u16) << 9)
                     + (offset & 0x1FF)
             }
+            Instruction::LoadRegister {
+                destination,
+                source,
+                offset,
+            } => {
+                ((OperationCode::Load as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + ((source as u16) << 6)
+                    + (offset & 0x3F)
+            }
             Instruction::LoadIndirect {
                 destination,
                 offset,
             } => {
                 ((OperationCode::LoadIndirect as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + (offset & 0x1FF)
+            }
+            Instruction::LoadEffectiveAddress {
+                destination,
+                offset,
+            } => {
+                ((OperationCode::LoadEffectiveAddress as u16) << 12)
                     + ((destination as u16) << 9)
                     + (offset & 0x1FF)
             }
@@ -182,7 +209,11 @@ impl Instruction {
             OperationCode::Store => todo!(),
             OperationCode::JumpRegister => todo!(),
             OperationCode::And => todo!(),
-            OperationCode::LoadRegister => todo!(),
+            OperationCode::LoadRegister => Instruction::LoadRegister {
+                destination: Register::from_bits(repr, 9),
+                source: Register::from_bits(repr, 6),
+                offset: from_bits_signed(repr, 6, 0),
+            },
             OperationCode::StoreRegister => todo!(),
             OperationCode::Rti => todo!(),
             OperationCode::Not => todo!(),
@@ -193,7 +224,10 @@ impl Instruction {
             OperationCode::StoreIndirect => todo!(),
             OperationCode::Jump => todo!(),
             OperationCode::Reserved => todo!(),
-            OperationCode::LoadEffectiveAddress => todo!(),
+            OperationCode::LoadEffectiveAddress => Instruction::LoadEffectiveAddress {
+                destination: Register::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::ExecuteTrap => todo!(),
         }
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -117,6 +117,10 @@ pub enum Instruction {
         mode: u16,
         value: u16,
     },
+    LoadIndirect {
+        destination: Register,
+        offset: u16,
+    },
     Noop,
 }
 
@@ -135,6 +139,12 @@ impl Instruction {
                     + ((source_1 as u16) << 6)
                     + (mode << 5)
                     + (value & 0x1F) // Kinda hack because value contains all of the bits of source_2
+            }
+            Instruction::LoadIndirect {
+                destination,
+                offset,
+            } => {
+                ((OperationCode::LoadIndirect as u16) << 12) + ((destination as u16) << 9) + (offset & 0x1FF)
             }
             Instruction::Noop => 0,
         }
@@ -159,7 +169,10 @@ impl Instruction {
             OperationCode::StoreRegister => todo!(),
             OperationCode::Rti => todo!(),
             OperationCode::Not => todo!(),
-            OperationCode::LoadIndirect => todo!(),
+            OperationCode::LoadIndirect => Instruction::LoadIndirect {
+                destination: Register::from_bits(repr, 9),
+                offset: from_bits_signed(repr, 9, 0),
+            },
             OperationCode::StoreIndirect => todo!(),
             OperationCode::Jump => todo!(),
             OperationCode::Reserved => todo!(),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -124,6 +124,10 @@ pub enum Instruction {
         mode: u16,
         value: u16,
     },
+    Not {
+        destination: Register,
+        source: Register,
+    },
     Load {
         destination: Register,
         offset: u16,
@@ -172,6 +176,14 @@ impl Instruction {
                     + ((source_1 as u16) << 6)
                     + (mode << 5)
                     + (value & 0x1F) // Kinda hack because value contains all of the bits of source_2
+            }
+            Instruction::Not {
+                destination,
+                source,
+            } => {
+                ((OperationCode::Not as u16) << 12)
+                    + ((destination as u16) << 9)
+                    + ((source as u16) << 6)
             }
             Instruction::Load {
                 destination,
@@ -242,7 +254,10 @@ impl Instruction {
             },
             OperationCode::StoreRegister => todo!(),
             OperationCode::Rti => todo!(),
-            OperationCode::Not => todo!(),
+            OperationCode::Not => Instruction::Not {
+                destination: Register::from_bits(repr, 9),
+                source: Register::from_bits(repr, 6),
+            },
             OperationCode::LoadIndirect => Instruction::LoadIndirect {
                 destination: Register::from_bits(repr, 9),
                 offset: from_bits_signed(repr, 9, 0),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -64,6 +64,18 @@ impl VirtualMachine {
                 offset,
             } => self.load_effective_address(destination, offset),
             Instruction::Branch { flag, offset } => self.branch(flag, offset),
+            Instruction::Jump { source } => self.jump(source),
+            Instruction::JumpRegister {
+                source,
+                mode,
+                offset,
+            } => {
+                if mode == 1 {
+                    self.jump_immediate(offset);
+                } else {
+                    self.jump_register(source);
+                }
+            }
             Instruction::Noop => (),
         }
     }
@@ -141,8 +153,23 @@ impl VirtualMachine {
     fn branch(&mut self, flag: ConditionFlag, offset: u16) {
         if flag as u16 == self.registers[Register::Cond as usize] {
             self.registers[Register::PC as usize] =
-                self.registers[Register::PC as usize].wrapping_add(offset)
+                self.registers[Register::PC as usize].wrapping_add(offset);
         }
+    }
+
+    fn jump(&mut self, source: Register) {
+        self.registers[Register::PC as usize] = self.registers[source as usize];
+    }
+
+    fn jump_immediate(&mut self, offset: u16) {
+        self.registers[Register::R7 as usize] = self.registers[Register::PC as usize];
+        let address = self.registers[Register::PC as usize].wrapping_add(offset);
+        self.registers[Register::PC as usize] = address;
+    }
+
+    fn jump_register(&mut self, source: Register) {
+        self.registers[Register::R7 as usize] = self.registers[Register::PC as usize];
+        self.registers[Register::PC as usize] = self.registers[source as usize];
     }
 }
 
@@ -448,5 +475,45 @@ mod tests {
         vm.registers[Register::Cond as usize] = ConditionFlag::Negative as u16;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::PC as usize], 3);
+    }
+
+    #[test]
+    fn vm_jump() {
+        let instruction = Instruction::Jump {
+            source: Register::R1,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::PC as usize] = 3;
+        vm.registers[Register::R1 as usize] = 6;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 6);
+    }
+
+    #[test]
+    fn vm_jump_immediate() {
+        let instruction = Instruction::JumpRegister {
+            source: Register::R1,
+            mode: 1,
+            offset: 0x8FF,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::PC as usize] = 3;
+        vm.registers[Register::R1 as usize] = 6;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 0x8FF + 3);
+    }
+
+    #[test]
+    fn vm_jump_register() {
+        let instruction = Instruction::JumpRegister {
+            source: Register::R1,
+            mode: 0,
+            offset: 0x40,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::PC as usize] = 3;
+        vm.registers[Register::R1 as usize] = 6;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 6);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -29,7 +29,11 @@ impl VirtualMachine {
                     self.add_immediate(destination, source_1, value);
                 }
             }
-            _ => (),
+            Instruction::LoadIndirect {
+                destination,
+                offset,
+            } => self.load_indirect(destination, offset),
+            Instruction::Noop => (),
         }
     }
 
@@ -53,6 +57,13 @@ impl VirtualMachine {
 
     fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
         value = value.wrapping_add(self.registers[source_1 as usize]);
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn load_indirect(&mut self, destination: Register, offset: u16) {
+        let address = self.registers[Register::PC as usize].wrapping_add(offset);
+        let value = self.memory[address as usize];
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
@@ -176,6 +187,33 @@ mod tests {
         assert_eq!(
             vm.registers[Register::Cond as usize],
             ConditionFlag::Zero as u16
+        );
+    }
+
+    #[test]
+    fn vm_load_indirect() {
+        let instruction = Instruction::LoadIndirect { destination: Register::R0, offset: 3 };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 45);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_load_indirect_negative() {
+        let instruction = Instruction::LoadIndirect { destination: Register::R0, offset: 0xFFFD };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.registers[Register::PC as usize] = 6;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 45);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
         );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -42,6 +42,10 @@ impl VirtualMachine {
                     self.and_immediate(destination, source_1, value);
                 }
             }
+            Instruction::Not {
+                destination,
+                source,
+            } => self.not(destination, source),
             Instruction::Load {
                 destination,
                 offset,
@@ -95,6 +99,12 @@ impl VirtualMachine {
 
     fn and_immediate(&mut self, destination: Register, source: Register, mut value: u16) {
         value = value & self.registers[source as usize];
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn not(&mut self, destination: Register, source: Register) {
+        let value = !(self.registers[source as usize]);
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
@@ -173,45 +183,6 @@ mod tests {
     }
 
     #[test]
-    fn vm_and() {
-        let instruction = Instruction::And {
-            destination: Register::R0,
-            source_1: Register::R0,
-            source_2: Register::R1,
-            mode: 0,
-            value: Register::R1 as u16,
-        };
-        let mut vm = VirtualMachine::new();
-        vm.registers[Register::R0 as usize] = 0xFFF0;
-        vm.registers[Register::R1 as usize] = 0x0FFF;
-        vm.execute_instruction(instruction);
-        assert_eq!(vm.registers[Register::R0 as usize], 0x0FF0);
-        assert_eq!(
-            vm.registers[Register::Cond as usize],
-            ConditionFlag::Positive as u16
-        );
-    }
-
-    #[test]
-    fn vm_and_immediate() {
-        let instruction = Instruction::And {
-            destination: Register::R0,
-            source_1: Register::R0,
-            source_2: Register::R1,
-            mode: 1,
-            value: 0xFFFF,
-        };
-        let mut vm = VirtualMachine::new();
-        vm.registers[Register::R0 as usize] = 0xFF00;
-        vm.execute_instruction(instruction);
-        assert_eq!(vm.registers[Register::R0 as usize], 0xFF00);
-        assert_eq!(
-            vm.registers[Register::Cond as usize],
-            ConditionFlag::Negative as u16
-        );
-    }
-
-    #[test]
     fn vm_add_immediate_negative() {
         let instruction = Instruction::Add {
             destination: Register::R0,
@@ -285,6 +256,61 @@ mod tests {
         assert_eq!(
             vm.registers[Register::Cond as usize],
             ConditionFlag::Zero as u16
+        );
+    }
+
+    #[test]
+    fn vm_and() {
+        let instruction = Instruction::And {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = 0xFFF0;
+        vm.registers[Register::R1 as usize] = 0x0FFF;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0x0FF0);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_and_immediate() {
+        let instruction = Instruction::And {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 0xFFFF,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = 0xFF00;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0xFF00);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Negative as u16
+        );
+    }
+
+    #[test]
+    fn vm_not() {
+        let instruction = Instruction::Not {
+            destination: Register::R0,
+            source: Register::R0,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = 0xFF00;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0x00FF);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
         );
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -76,6 +76,13 @@ impl VirtualMachine {
                     self.jump_register(source);
                 }
             }
+            Instruction::Store { source, offset } => self.store(source, offset),
+            Instruction::StoreIndirect { source, offset } => self.store_indirect(source, offset),
+            Instruction::StoreRegister {
+                source_1,
+                source_2,
+                offset,
+            } => self.store_register(source_1, source_2, offset),
             Instruction::Noop => (),
         }
     }
@@ -170,6 +177,22 @@ impl VirtualMachine {
     fn jump_register(&mut self, source: Register) {
         self.registers[Register::R7 as usize] = self.registers[Register::PC as usize];
         self.registers[Register::PC as usize] = self.registers[source as usize];
+    }
+
+    fn store(&mut self, source: Register, offset: u16) {
+        let address: usize = offset.wrapping_add(self.registers[Register::PC as usize]) as usize;
+        self.memory[address] = self.registers[source as usize];
+    }
+
+    fn store_indirect(&mut self, source: Register, offset: u16) {
+        let meta_address = self.registers[Register::PC as usize].wrapping_add(offset) as usize;
+        let address = self.memory[meta_address] as usize;
+        self.memory[address] = self.registers[source as usize];
+    }
+
+    fn store_register(&mut self, source_1: Register, source_2: Register, offset: u16) {
+        let address: usize = offset.wrapping_add(self.registers[source_2 as usize]) as usize;
+        self.memory[address] = self.registers[source_1 as usize];
     }
 }
 
@@ -515,5 +538,47 @@ mod tests {
         vm.registers[Register::R1 as usize] = 6;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::PC as usize], 6);
+    }
+
+    #[test]
+    fn vm_store() {
+        let instruction = Instruction::Store {
+            source: Register::R1,
+            offset: 0x40,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 6;
+        vm.execute_instruction(instruction);
+        let address = (vm.registers[Register::PC as usize] + 0x40) as usize;
+        assert_eq!(vm.memory[address], 6);
+    }
+
+    #[test]
+    fn vm_store_indirect() {
+        let instruction = Instruction::StoreIndirect {
+            source: Register::R1,
+            offset: 0x40,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 6;
+        let address = (vm.registers[Register::PC as usize] + 0x40) as usize;
+        vm.memory[address] = 50;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.memory[50], 6);
+    }
+
+    #[test]
+    fn vm_store_register() {
+        let instruction = Instruction::StoreRegister {
+            source_1: Register::R1,
+            source_2: Register::R2,
+            offset: 0x40,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R1 as usize] = 6;
+        vm.registers[Register::R2 as usize] = 40;
+        vm.execute_instruction(instruction);
+        let address = (40 + 0x40) as usize;
+        assert_eq!(vm.memory[address], 6);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -234,4 +234,39 @@ mod tests {
             ConditionFlag::Positive as u16
         );
     }
+
+    #[test]
+    fn vm_load_indirect() {
+        let instruction = Instruction::LoadIndirect {
+            destination: Register::R0,
+            offset: 3,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.memory[45] = 42;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 42);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_load_indirect_negative() {
+        let instruction = Instruction::LoadIndirect {
+            destination: Register::R0,
+            offset: 0xFFFD,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.memory[45] = 42;
+        vm.registers[Register::PC as usize] = 6;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 42);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -33,10 +33,19 @@ impl VirtualMachine {
                 destination,
                 offset,
             } => self.load(destination, offset),
+            Instruction::LoadRegister {
+                destination,
+                source,
+                offset,
+            } => self.load_register(destination, source, offset),
             Instruction::LoadIndirect {
                 destination,
                 offset,
             } => self.load_indirect(destination, offset),
+            Instruction::LoadEffectiveAddress {
+                destination,
+                offset,
+            } => self.load_effective_address(destination, offset),
             Instruction::Noop => (),
         }
     }
@@ -52,15 +61,15 @@ impl VirtualMachine {
         }
     }
 
-    fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
+    fn add(&mut self, destination: Register, source_1: Register, source_2: Register) {
         let value =
-            self.registers[source_1 as usize].wrapping_add(self.registers[sorce_2 as usize]);
+            self.registers[source_1 as usize].wrapping_add(self.registers[source_2 as usize]);
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
 
-    fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
-        value = value.wrapping_add(self.registers[source_1 as usize]);
+    fn add_immediate(&mut self, destination: Register, source: Register, mut value: u16) {
+        value = value.wrapping_add(self.registers[source as usize]);
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
@@ -72,10 +81,23 @@ impl VirtualMachine {
         self.update_flags(value);
     }
 
+    fn load_register(&mut self, destination: Register, source: Register, offset: u16) {
+        let address = self.registers[source as usize].wrapping_add(offset);
+        let value = self.memory[address as usize];
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
     fn load_indirect(&mut self, destination: Register, offset: u16) {
         let meta_address = self.registers[Register::PC as usize].wrapping_add(offset);
         let address = self.memory[meta_address as usize];
         let value = self.memory[address as usize];
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn load_effective_address(&mut self, destination: Register, offset: u16) {
+        let value = self.registers[Register::PC as usize].wrapping_add(offset);
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
@@ -264,6 +286,41 @@ mod tests {
         vm.registers[Register::PC as usize] = 6;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 42);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_load_register() {
+        let instruction = Instruction::LoadRegister {
+            destination: Register::R0,
+            source: Register::R0,
+            offset: 3,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.memory[45] = 42;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 45);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_load_effective_address() {
+        let instruction = Instruction::LoadEffectiveAddress {
+            destination: Register::R0,
+            offset: 3,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.memory[3] = 45;
+        vm.memory[45] = 42;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 3);
         assert_eq!(
             vm.registers[Register::Cond as usize],
             ConditionFlag::Positive as u16

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -24,9 +24,22 @@ impl VirtualMachine {
                 value,
             } => {
                 if mode == 0 {
-                    self.add(destination, source_1, source_2)
+                    self.add(destination, source_1, source_2);
                 } else {
                     self.add_immediate(destination, source_1, value);
+                }
+            }
+            Instruction::And {
+                destination,
+                source_1,
+                source_2,
+                mode,
+                value,
+            } => {
+                if mode == 0 {
+                    self.and(destination, source_1, source_2);
+                } else {
+                    self.and_immediate(destination, source_1, value);
                 }
             }
             Instruction::Load {
@@ -70,6 +83,18 @@ impl VirtualMachine {
 
     fn add_immediate(&mut self, destination: Register, source: Register, mut value: u16) {
         value = value.wrapping_add(self.registers[source as usize]);
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn and(&mut self, destination: Register, source_1: Register, source_2: Register) {
+        let value = self.registers[source_1 as usize] & self.registers[source_2 as usize];
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn and_immediate(&mut self, destination: Register, source: Register, mut value: u16) {
+        value = value & self.registers[source as usize];
         self.registers[destination as usize] = value;
         self.update_flags(value);
     }
@@ -144,6 +169,45 @@ mod tests {
         assert_eq!(
             vm.registers[Register::Cond as usize],
             ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_and() {
+        let instruction = Instruction::And {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 0,
+            value: Register::R1 as u16,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = 0xFFF0;
+        vm.registers[Register::R1 as usize] = 0x0FFF;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0x0FF0);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
+    }
+
+    #[test]
+    fn vm_and_immediate() {
+        let instruction = Instruction::And {
+            destination: Register::R0,
+            source_1: Register::R0,
+            source_2: Register::R1,
+            mode: 1,
+            value: 0xFFFF,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::R0 as usize] = 0xFF00;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::R0 as usize], 0xFF00);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Negative as u16
         );
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -63,6 +63,7 @@ impl VirtualMachine {
                 destination,
                 offset,
             } => self.load_effective_address(destination, offset),
+            Instruction::Branch { flag, offset } => self.branch(flag, offset),
             Instruction::Noop => (),
         }
     }
@@ -135,6 +136,13 @@ impl VirtualMachine {
         let value = self.registers[Register::PC as usize].wrapping_add(offset);
         self.registers[destination as usize] = value;
         self.update_flags(value);
+    }
+
+    fn branch(&mut self, flag: ConditionFlag, offset: u16) {
+        if flag as u16 == self.registers[Register::Cond as usize] {
+            self.registers[Register::PC as usize] =
+                self.registers[Register::PC as usize].wrapping_add(offset)
+        }
     }
 }
 
@@ -415,5 +423,30 @@ mod tests {
             vm.registers[Register::Cond as usize],
             ConditionFlag::Positive as u16
         );
+    }
+
+    #[test]
+    fn vm_branch() {
+        let instruction = Instruction::Branch {
+            flag: ConditionFlag::Negative,
+            offset: 16,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::Cond as usize] = ConditionFlag::Negative as u16;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 16);
+    }
+
+    #[test]
+    fn vm_branch_fail() {
+        let instruction = Instruction::Branch {
+            flag: ConditionFlag::Positive,
+            offset: 16,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::PC as usize] = 3;
+        vm.registers[Register::Cond as usize] = ConditionFlag::Negative as u16;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 3);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -29,6 +29,10 @@ impl VirtualMachine {
                     self.add_immediate(destination, source_1, value);
                 }
             }
+            Instruction::Load {
+                destination,
+                offset,
+            } => self.load(destination, offset),
             Instruction::LoadIndirect {
                 destination,
                 offset,
@@ -61,8 +65,16 @@ impl VirtualMachine {
         self.update_flags(value);
     }
 
-    fn load_indirect(&mut self, destination: Register, offset: u16) {
+    fn load(&mut self, destination: Register, offset: u16) {
         let address = self.registers[Register::PC as usize].wrapping_add(offset);
+        let value = self.memory[address as usize];
+        self.registers[destination as usize] = value;
+        self.update_flags(value);
+    }
+
+    fn load_indirect(&mut self, destination: Register, offset: u16) {
+        let meta_address = self.registers[Register::PC as usize].wrapping_add(offset);
+        let address = self.memory[meta_address as usize];
         let value = self.memory[address as usize];
         self.registers[destination as usize] = value;
         self.update_flags(value);
@@ -191,8 +203,8 @@ mod tests {
     }
 
     #[test]
-    fn vm_load_indirect() {
-        let instruction = Instruction::LoadIndirect {
+    fn vm_load() {
+        let instruction = Instruction::Load {
             destination: Register::R0,
             offset: 3,
         };
@@ -207,8 +219,8 @@ mod tests {
     }
 
     #[test]
-    fn vm_load_indirect_negative() {
-        let instruction = Instruction::LoadIndirect {
+    fn vm_load_negative() {
+        let instruction = Instruction::Load {
             destination: Register::R0,
             offset: 0xFFFD,
         };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-use crate::instructions::{Instruction, REGISTER_COUNTER, Register};
+use crate::instructions::{ConditionFlag, Instruction, REGISTER_COUNTER, Register};
 
 #[derive(Debug, Clone, Copy)]
 pub struct VirtualMachine {
@@ -33,20 +33,35 @@ impl VirtualMachine {
         }
     }
 
+    fn update_flags(&mut self, value: u16) {
+        // The wrapping add is necessary, because u16 doesn't know that a leading 1 indicates
+        // a negative value
+        self.registers[Register::Cond as usize] = match value.wrapping_add(1 << 15).cmp(&(1 << 15))
+        {
+            std::cmp::Ordering::Less => ConditionFlag::Negative as u16,
+            std::cmp::Ordering::Equal => ConditionFlag::Zero as u16,
+            std::cmp::Ordering::Greater => ConditionFlag::Positive as u16,
+        }
+    }
+
     fn add(&mut self, destination: Register, source_1: Register, sorce_2: Register) {
         let value =
             self.registers[source_1 as usize].wrapping_add(self.registers[sorce_2 as usize]);
         self.registers[destination as usize] = value;
+        self.update_flags(value);
     }
 
     fn add_immediate(&mut self, destination: Register, source_1: Register, mut value: u16) {
         value = value.wrapping_add(self.registers[source_1 as usize]);
         self.registers[destination as usize] = value;
+        self.update_flags(value);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::instructions::ConditionFlag;
+
     use super::*;
 
     #[test]
@@ -62,6 +77,10 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 2);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
     }
 
     #[test]
@@ -77,6 +96,10 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 5);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
     }
 
     #[test]
@@ -92,6 +115,10 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 0xFFFF);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Negative as u16
+        );
     }
 
     #[test]
@@ -107,6 +134,10 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize].wrapping_add(16), 0);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Negative as u16
+        );
     }
 
     #[test]
@@ -123,6 +154,10 @@ mod tests {
         vm.registers[Register::R1 as usize] = 2;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 1);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Positive as u16
+        );
     }
 
     #[test]
@@ -138,5 +173,9 @@ mod tests {
         vm.registers[Register::R0 as usize] = u16::MAX - 14;
         vm.execute_instruction(instruction);
         assert_eq!(vm.registers[Register::R0 as usize], 0);
+        assert_eq!(
+            vm.registers[Register::Cond as usize],
+            ConditionFlag::Zero as u16
+        );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -192,7 +192,10 @@ mod tests {
 
     #[test]
     fn vm_load_indirect() {
-        let instruction = Instruction::LoadIndirect { destination: Register::R0, offset: 3 };
+        let instruction = Instruction::LoadIndirect {
+            destination: Register::R0,
+            offset: 3,
+        };
         let mut vm = VirtualMachine::new();
         vm.memory[3] = 45;
         vm.execute_instruction(instruction);
@@ -205,7 +208,10 @@ mod tests {
 
     #[test]
     fn vm_load_indirect_negative() {
-        let instruction = Instruction::LoadIndirect { destination: Register::R0, offset: 0xFFFD };
+        let instruction = Instruction::LoadIndirect {
+            destination: Register::R0,
+            offset: 0xFFFD,
+        };
         let mut vm = VirtualMachine::new();
         vm.memory[3] = 45;
         vm.registers[Register::PC as usize] = 6;


### PR DESCRIPTION
Adding the following instructions
```
    OP_LD,     /* load */
    OP_ST,     /* store */
    OP_JSR,    /* jump register */
    OP_AND,    /* bitwise and */
    OP_LDR,    /* load register */
    OP_STR,    /* store register */
    OP_NOT,    /* bitwise not */
    OP_LDI,    /* load indirect */
    OP_STI,    /* store indirect */
    OP_JMP,    /* jump */
    OP_LEA,    /* load effective address */
```    
And making sure cond flags are properly updated.