### PR TITLE
Fixed Flags for Branch Instructions

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -90,23 +90,6 @@ pub enum ConditionFlag {
     Zero = 1 << 1,
     Negative = 1 << 2,
 }
-impl ConditionFlag {
-    fn from_u16(value: u16) -> Self {
-        match value {
-            1 => Self::Positive,
-            2 => Self::Zero,
-            4 => Self::Negative,
-            _ => {
-                /* consider blowing up */
-                todo!()
-            }
-        }
-    }
-
-    fn from_bits(value: u16, offset: u16) -> Self {
-        Self::from_u16(from_bits(value, 3, offset))
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Register {
@@ -187,7 +170,7 @@ pub enum Instruction {
         offset: u16,
     },
     Branch {
-        flag: ConditionFlag,
+        flag: u16,
         offset: u16,
     },
     Jump {
@@ -329,7 +312,7 @@ impl Instruction {
         let code = OperationCode::from_u16(repr >> 12);
         match code {
             OperationCode::Branch => Instruction::Branch {
-                flag: ConditionFlag::from_bits(repr, 9),
+                flag: from_bits(repr, 9, 0),
                 offset: from_bits_signed(repr, 9, 0),
             },
             OperationCode::Add => Instruction::Add {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -190,8 +190,8 @@ impl VirtualMachine {
         self.update_flags(value);
     }
 
-    fn branch(&mut self, flag: ConditionFlag, offset: u16) {
-        if flag as u16 == self.registers[Register::Cond as usize] {
+    fn branch(&mut self, flag: u16, offset: u16) {
+        if (flag & self.registers[Register::Cond as usize]) != 0 {
             self.registers[Register::PC as usize] =
                 self.registers[Register::PC as usize].wrapping_add(offset);
         }
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn vm_branch() {
         let instruction = Instruction::Branch {
-            flag: ConditionFlag::Negative,
+            flag: ConditionFlag::Negative as u16,
             offset: 16,
         };
         let mut vm = VirtualMachine::new();
@@ -597,9 +597,21 @@ mod tests {
     }
 
     #[test]
+    fn vm_branch_multiple() {
+        let instruction = Instruction::Branch {
+            flag: ConditionFlag::Negative as u16 | ConditionFlag::Positive as u16,
+            offset: 16,
+        };
+        let mut vm = VirtualMachine::new();
+        vm.registers[Register::Cond as usize] = ConditionFlag::Positive as u16;
+        vm.execute_instruction(instruction);
+        assert_eq!(vm.registers[Register::PC as usize], 16);
+    }
+
+    #[test]
     fn vm_branch_fail() {
         let instruction = Instruction::Branch {
-            flag: ConditionFlag::Positive,
+            flag: 0,
             offset: 16,
         };
         let mut vm = VirtualMachine::new();


### PR DESCRIPTION
The branch command was assuming that each branch instruction had 1 and only 1 flag on which to jump, which doesn't reflect the spec. In the spec, the branch can jump with any combinations of condition flags. This change fixes that assumption.